### PR TITLE
Correcting code to be compatible with catalog names that are formatte…

### DIFF
--- a/src/discord-update-report.js
+++ b/src/discord-update-report.js
@@ -7,8 +7,10 @@ function formatReport(report) {
   out.push('');
   out.push('**CATALOG UPDATE**');
   for (const r of report) {
+    var data = require(`${(r.catalog, { replacement: '-', remove: /[#,.:?()'"/]/g, lower: true }).toLowerCase()}.json`)
+    
     out.push(
-      `- [${r.catalog}](https://keycap-archivist.com/maker/${slugify(r.catalog, {
+      `- [${r.catalog}](https://keycap-archivist.com/maker/${slugify(JSON.stringify(data.name, {
         replacement: '-',
         remove: /[#,.:?()'"/]/g,
         lower: true,


### PR DESCRIPTION
…d different

Correcting code to be compatible with catalog names that are formatted different.. 
Before.. catalog names including fullstops/periods in the r.catalog string but dashes instead in the database json and csv file name.. were unusable for hyperlinks.. and so fourth would link you to a 404 page if you tried to use the hyperlink.. 

When this code is approved the catalog names that had problems with being linked in the past with hperlinks shall work!