### PR TITLE
fix: kwk IG link

### DIFF
--- a/src/importer/json/kbk.json
+++ b/src/importer/json/kbk.json
@@ -2,7 +2,7 @@
   "docId": "1656SEjL_uolfVYeUgiAjbelyM_HhxAg77oTCPWiviD8",
   "name": "KBK-KWK",
   "website": "https://geekhack.org/index.php?topic=55490.0",
-  "instagram": "https://www.instagram.com/hipsterpunks/",
+  "instagram": "https://www.instagram.com/kultworshipkaps/",
   "artisanCollector": "https://artisancollector.com/kwk-kbk/",
   "tabsOperations": ["pop"]
 }


### PR DESCRIPTION
The link currently here appears to be for some NFT project. Added the IG account that is used for KWK releases