### PR TITLE
Fix Self Ordering

### DIFF
--- a/src/google/index.js
+++ b/src/google/index.js
@@ -33,7 +33,7 @@ function gDocParse (catalog, jsonDoc) {
   jp.query(jsonDoc.data.body.content, '$..textRun').forEach(x => {
     const nat = getNationality(x.content)
     if (nat) { catalog.nationality = nat }
-    if (isSelfOrdered(x.content)) { catalog.isSelfOrdered = true }
+    if (isSelfOrdered(x.content)) { catalog.selfOrder = true }
   })
 
   // parse all the tables


### PR DESCRIPTION
I think [Pears](https://github.com/sillypears) fixed Self Ordering but was too lazy to test it out, so I shot my shot and I think it works?

I did the Google Docs API setup to get an appropriate key.json file, and then (in my environment's) generate.js I added a line to the maker summary which would output the selfOrder variable for each maker. Once the index.js change was implemented, I was able to see my own catalog summary output selfOrder=true. It was previously outputting selfOrder=False. I believe this is what will fix the self ordering.