### PR TITLE
Feature: Add ability to add stem type(s)

### DIFF
--- a/src/google/index.js
+++ b/src/google/index.js
@@ -76,11 +76,15 @@ function gDocParse (catalog, jsonDoc) {
         const regPhotoCredit = /\(pc (.*)\)/gim
         const photoCreditMatch = regPhotoCredit.exec(cellString)
 
+        const regStemType = /\(stemtype\s+((?:topre|mx|alps|tmx|choc|bs)(?:\s+(?:topre|mx|alps|tmx|choc|bs))*)\b\)/gim
+        const stemTypeMatch = regStemType.exec(cellString)
+
         let releaseDate
         let totalCount
         let commissioned
         let giveaway
         let photoCredit
+        let stemType = ["mx"]
 
         if (dateMatch) {
           // eslint-disable-next-line prefer-destructuring
@@ -106,6 +110,12 @@ function gDocParse (catalog, jsonDoc) {
           cellString = cellString.replace(regPhotoCredit, '')
         }
 
+        if (stemTypeMatch) {
+          stemType = stemTypeMatch.slice(1)
+          stemType = stemType[0].split(' ')
+          cellString = cellString.replace(regStemType, '')
+        }
+        
         const sanitizedName = cellString.trim()
         const imgKixId = imgId[0]
         catalog.sculpts[catalog.sculpts.length - 1].colorways.push(
@@ -119,6 +129,7 @@ function gDocParse (catalog, jsonDoc) {
             commissioned,
             giveaway,
             photoCredit,
+            stemType,
             note: ''
           }
         )

--- a/src/google/index.js
+++ b/src/google/index.js
@@ -84,7 +84,7 @@ function gDocParse (catalog, jsonDoc) {
         let commissioned
         let giveaway
         let photoCredit
-        let stemType = ["mx"]
+        let stemType
 
         if (dateMatch) {
           // eslint-disable-next-line prefer-destructuring

--- a/templates/README.md
+++ b/templates/README.md
@@ -36,7 +36,7 @@ To manipulate some attributes of the catalogs you can add those to the gdoc:
 - **Colorway Header** `(*)` will add a "Commission" tag to the colorway page. `(*)` is removed from the colorway title.
 - **Colorway Header** `(giveaway)` or `(give-away)` to note if a colorway was specificly for a giveaway
 - **Colorway Header** `(pc Name)` will add photo credit to denote who owns the photo: `(pc Brandon Stanton)`
-- **Colorway Header** `(stemtype mx|topre|alps|choc|tmx|bs)` will add stem types to each colorway. This can default to MX as the most used stem. Any number of options can be listed separated by a space: `(stemtype topre)` `(stemtype mx topre alps)`
+- **Colorway Header** `(stemtype mx|topre|alps|choc|tmx|bs)` will add stem types to each colorway. Any number of options can be listed separated by a space: `(stemtype topre)` `(stemtype mx topre alps)`
 
 ## Source Catalogs
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -36,6 +36,7 @@ To manipulate some attributes of the catalogs you can add those to the gdoc:
 - **Colorway Header** `(*)` will add a "Commission" tag to the colorway page. `(*)` is removed from the colorway title.
 - **Colorway Header** `(giveaway)` or `(give-away)` to note if a colorway was specificly for a giveaway
 - **Colorway Header** `(pc Name)` will add photo credit to denote who owns the photo: `(pc Brandon Stanton)`
+- **Colorway Header** `(stemtype mx|topre|alps|choc|tmx|bs)` will add stem types to each colorway. This can default to MX as the most used stem. Any number of options can be listed separated by a space: `(stemtype topre)` `(stemtype mx topre alps)`
 
 ## Source Catalogs
 


### PR DESCRIPTION
Let's maintainers add the type of stem used for each colorway. Thought about adding a default of MX but realized this was probably a bad idea. Letting maintainers add MX for their caps is required, along with any other stem type used for each colorweay.

I tested this in ways I thought needed to be but I think it should be verified, I only really tested with my own catalog